### PR TITLE
use latest Go 1 release in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9-alpine
+FROM golang:1-alpine
 
 WORKDIR /go/src/
 


### PR DESCRIPTION
The [Go compatibility guarantees](https://golang.org/doc/go1compat#expectations) make it safe to always use the latest Go 1 release.